### PR TITLE
improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM alpine:latest
-RUN mkdir /app
-COPY . /app
+FROM alpine:3.19 as builder
+COPY . /tmp/app
 RUN apk update && \
     apk add build-base cmake gdb valgrind cmocka-dev openssl-dev
-RUN mkdir /app/build
-WORKDIR /app/build
-RUN cmake .. && \
-    cmake --build .
-WORKDIR /app
-CMD ["/app/build/main"]
+
+RUN mkdir /tmp/app/build && \
+    cd /tmp/app/build && \
+    cmake /tmp/app && \
+    cmake --build /tmp/app/build
+
+FROM alpine:3.19
+COPY --from=builder /tmp/app/build/main /
+CMD ["/main"]


### PR DESCRIPTION
The current Dockerfile leaves all build tools on the deployed image.

Instead use a builder to build the application and then only explicitly copy the binary to the container.

Additionally, alpine:latest is unpinned to a release. Explicitly pin to a release.